### PR TITLE
Fixed 500 error that was thrown while requesting particular dates, added a query parameter to output video thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ as parameters to a http GET request. A JSON dictionary is returned nominally.
 - `count` A positive integer, no greater than 100. If this is specified then `count` randomly chosen images will be returned in a JSON array. Cannot be used in conjunction with `date` or `start_date` and `end_date`.
 - `start_date` A string in YYYY-MM-DD format indicating the start of a date range. All images in the range from `start_date` to `end_date` will be returned in a JSON array. Cannot be used with `date`.
 - `end_date` A string in YYYY-MM-DD format indicating that end of a date range. If `start_date` is specified without an `end_date` then `end_date` defaults to the current date.
+- `thumbs` If set to `true`, the API returns URL of video thumbnail. If an APOD is not a video, this parameter is ignored.
 
 **Returned fields**
 
@@ -29,6 +30,7 @@ as parameters to a http GET request. A JSON dictionary is returned nominally.
 - `media_type` The type of media (data) returned. May either be 'image' or 'video' depending on content.
 - `explanation` The supplied text explanation of the image.
 - `concepts` The most relevant concepts within the text explanation.  Only supplied if `concept_tags` is set to True.
+- `thumbnail_url` The URL of thumbnail of the video. 
 
 **Example**
 

--- a/apod/service.py
+++ b/apod/service.py
@@ -27,7 +27,7 @@ logging.basicConfig(level=logging.DEBUG)
 # assorted libraries
 SERVICE_VERSION = 'v1'
 APOD_METHOD_NAME = 'apod'
-ALLOWED_APOD_FIELDS = ['concept_tags', 'date', 'hd', 'count', 'start_date', 'end_date']
+ALLOWED_APOD_FIELDS = ['concept_tags', 'date', 'hd', 'count', 'start_date', 'end_date', 'thumbs']
 ALCHEMY_API_KEY = None
 
 try:
@@ -74,13 +74,13 @@ def _validate_date(dt):
         raise ValueError('Date must be between %s and %s.' % (begin_str, today_str))
 
 
-def _apod_handler(dt, use_concept_tags=False, use_default_today_date=False):
+def _apod_handler(dt, use_concept_tags=False, use_default_today_date=False, thumbs=False):
     """
     Accepts a parameter dictionary. Returns the response object to be
     served through the API.
     """
     try:
-        page_props = parse_apod(dt, use_default_today_date)
+        page_props = parse_apod(dt, use_default_today_date, thumbs)
         LOG.debug('managed to get apod page characteristics')
 
         if use_concept_tags:
@@ -98,7 +98,7 @@ def _apod_handler(dt, use_concept_tags=False, use_default_today_date=False):
         return _abort(500, 'Internal Service Error', usage=False)
 
 
-def _get_json_for_date(input_date, use_concept_tags):
+def _get_json_for_date(input_date, use_concept_tags, thumbs):
     """
     This returns the JSON data for a specific date, which must be a string of the form YYYY-MM-DD. If date is None,
     then it defaults to the current date.
@@ -119,14 +119,14 @@ def _get_json_for_date(input_date, use_concept_tags):
     _validate_date(dt)
 
     # get data
-    data = _apod_handler(dt, use_concept_tags, use_default_today_date)
+    data = _apod_handler(dt, use_concept_tags, use_default_today_date, thumbs)
     data['service_version'] = SERVICE_VERSION
 
     # return info as JSON
     return jsonify(data)
 
 
-def _get_json_for_random_dates(count, use_concept_tags):
+def _get_json_for_random_dates(count, use_concept_tags, thumbs):
     """
     This returns the JSON data for a set of randomly chosen dates. The number of dates is specified by the count
     parameter
@@ -147,14 +147,14 @@ def _get_json_for_random_dates(count, use_concept_tags):
     all_data = []
     for date_ordinal in random_date_ordinals:
         dt = date.fromordinal(date_ordinal)
-        data = _apod_handler(dt, use_concept_tags, date_ordinal == today_ordinal)
+        data = _apod_handler(dt, use_concept_tags, date_ordinal == today_ordinal, thumbs)
         data['service_version'] = SERVICE_VERSION
         all_data.append(data)
 
     return jsonify(all_data)
 
 
-def _get_json_for_date_range(start_date, end_date, use_concept_tags):
+def _get_json_for_date_range(start_date, end_date, use_concept_tags, thumbs):
     """
     This returns the JSON data for a range of dates, specified by start_date and end_date, which must be strings of the
     form YYYY-MM-DD. If end_date is None then it defaults to the current date.
@@ -188,7 +188,7 @@ def _get_json_for_date_range(start_date, end_date, use_concept_tags):
     while start_ordinal <= end_ordinal:
         # get data
         dt = date.fromordinal(start_ordinal)
-        data = _apod_handler(dt, use_concept_tags, start_ordinal == today_ordinal)
+        data = _apod_handler(dt, use_concept_tags, start_ordinal == today_ordinal, thumbs)
         data['service_version'] = SERVICE_VERSION
 
         if data['date'] == dt.isoformat():
@@ -218,7 +218,7 @@ def apod():
     LOG.info('apod path called')
     try:
 
-        # application/json GET method 
+        # application/json GET method
         args = request.args
 
         if not _validate(args):
@@ -230,15 +230,16 @@ def apod():
         start_date = args.get('start_date')
         end_date = args.get('end_date')
         use_concept_tags = args.get('concept_tags', False)
+        thumbs = args.get('thumbs', False)
 
         if not count and not start_date and not end_date:
-            return _get_json_for_date(input_date, use_concept_tags)
+            return _get_json_for_date(input_date, use_concept_tags, thumbs)
 
         elif not input_date and not start_date and not end_date and count:
-            return _get_json_for_random_dates(int(count), use_concept_tags)
+            return _get_json_for_random_dates(int(count), use_concept_tags, thumbs)
 
         elif not count and not input_date and start_date:
-            return _get_json_for_date_range(start_date, end_date, use_concept_tags)
+            return _get_json_for_date_range(start_date, end_date, use_concept_tags, thumbs)
 
         else:
             return _abort(400, 'Bad Request: invalid field combination passed.')

--- a/apod/templates/home.html
+++ b/apod/templates/home.html
@@ -9,7 +9,7 @@
 
 <h3>Service API</h3>
 <p>
-This service contains a single endpoint, &quot;<i>/{{ version }}/{{ methodname }}/</i>&quot;, 
+This service contains a single endpoint, &quot;<i>/{{ version }}/{{ methodname }}/</i>&quot;,
 which may be used to obtain a selected image url and metadata from http://apod.nasa.gov.
 
 You can use this service endpoint by sending a GET request which may contain one or
@@ -17,12 +17,12 @@ more of the following parameters which direct its output:
 <table border="1">
 <tbody>
 <tr><th>Allowed Field</th><th>Description</th></tr>
-<tr><td><b>date</b></td><td>A string in YYYY-MM-DD format indicating the date of the APOD image 
-(example: 2014-11-03).  Must be after 1995-06-16, the first day an APOD picture was posted.  
-There are no images for tomorrow available through this API. <i>Defaults to today's date.</i></td></tr> 
-<tr><td><b>concept_tags</b></td><td>A boolean indicating whether concept tags should be returned with the 
-rest of the response.  The concept tags are not necessarily included in the explanation, but 
-rather derived from common search tags that are associated with the description text. 
+<tr><td><b>date</b></td><td>A string in YYYY-MM-DD format indicating the date of the APOD image
+(example: 2014-11-03).  Must be after 1995-06-16, the first day an APOD picture was posted.
+There are no images for tomorrow available through this API. <i>Defaults to today's date.</i></td></tr>
+<tr><td><b>concept_tags</b></td><td>A boolean indicating whether concept tags should be returned with the
+rest of the response.  The concept tags are not necessarily included in the explanation, but
+rather derived from common search tags that are associated with the description text.
 (Better than just pure text search.). <i>Defaults to False.</i></td></tr>
 </tbody></table>
 </p><p>
@@ -34,8 +34,8 @@ curl http://{{ service_url }}/{{ version }}/{{ methodname }}/?concept_tags=True&
 </pre>
 </font>
 </p><p>
-which should return an application/json response with a JSON formatted string containing 
-the desired information. 
+which should return an application/json response with a JSON formatted string containing
+the desired information.
 For example, the return JSON from the above query is:
 </p><p>
 <pre>
@@ -53,13 +53,14 @@ Returned field meanings are as follows:
 </p><p>
 <table border="1"><tbody>
 <tr><th>Returned Field</th><th>Description</th></tr>
-<tr><td><b>resource</b></td>    <td>A dictionary describing the `image_set` or `planet` that the 
+<tr><td><b>resource</b></td>    <td>A dictionary describing the `image_set` or `planet` that the
 response illustrates, completely determined by the structured endpoint</td></tr>
 <tr><td><b>concept_tags</b></td><td>A boolean reflection of the supplied option.  Included in response because of default values.</td></tr>
-<tr><td><b>title</b></td>       <td>The title of the image.</td></tr> 
+<tr><td><b>title</b></td>       <td>The title of the image.</td></tr>
 <tr><td><b>date</b></td>        <td>Date of image. Included in response because of default values.</td></tr>
-<tr><td><b>url</b></td>         <td>The URL of the APOD image of the day.</td></tr> 
+<tr><td><b>url</b></td>         <td>The URL of the APOD image of the day.</td></tr>
 <tr><td><b>explanation</b></td> <td>The supplied text explanation of the image.</td></tr>
 <tr><td><b>concepts</b></td>    <td>The most relevant concepts within the text explanation.  Only supplied if `concept_tags` is set to True.</td></tr>
+<tr><td><b>thumbnail_url</b></td>    <td>The URL of thumbnail of the video.  Only supplied if `thumbs` is set to True.</td></tr>
 </tbody></table>
 </body></html>

--- a/apod/utility.py
+++ b/apod/utility.py
@@ -4,6 +4,9 @@ Split off some library functions for easier testing and code management.
 Created on Mar 24, 2017
 
 @author=bathomas @email=brian.a.thomas@nasa.gov
+
+Modified on Oct 10, 2018
+@author=PawelPleskaczynski @email=pawelpleskaczynski@gmail.com
 """
 
 from bs4 import BeautifulSoup
@@ -37,10 +40,14 @@ def _get_apod_chars(dt):
             if link['href'] and link['href'].startswith('image'):
                 hd_data = BASE + link['href']
                 break
-    else:
+    elif soup.iframe:
         # its a video
         media_type = 'video'
         data = soup.iframe['src']
+    else:
+        # it is neither image nor video, output empty urls
+        media_type = 'other'
+        data = ''
 
     props = {}
 
@@ -50,7 +57,8 @@ def _get_apod_chars(dt):
     if copyright_text:
         props['copyright'] = copyright_text
     props['media_type'] = media_type
-    props['url'] = data
+    if data:
+        props['url'] = data
     props['date'] = dt.isoformat()
 
     if hd_data:

--- a/apod/utility.py
+++ b/apod/utility.py
@@ -4,9 +4,6 @@ Split off some library functions for easier testing and code management.
 Created on Mar 24, 2017
 
 @author=bathomas @email=brian.a.thomas@nasa.gov
-
-Modified on Oct 10, 2018
-@author=PawelPleskaczynski @email=pawelpleskaczynski@gmail.com
 """
 
 from bs4 import BeautifulSoup
@@ -14,6 +11,8 @@ from datetime import timedelta
 import requests
 import logging
 import json
+import re
+import urllib.request
 
 LOG = logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARN)
@@ -22,7 +21,32 @@ logging.basicConfig(level=logging.WARN)
 BASE = 'https://apod.nasa.gov/apod/'
 
 
-def _get_apod_chars(dt):
+# function for getting video thumbnails
+def _get_thumbs(data):
+    global video_thumb
+    if "youtube" in data or "youtu.be" in data:
+        # get ID from YouTube URL
+        youtube_id_regex = re.compile("(?:(?<=(v|V)/)|(?<=be/)|(?<=(\?|\&)v=)|(?<=embed/))([\w-]+)")
+        video_id = youtube_id_regex.findall(data)
+        video_id = ''.join(''.join(elements) for elements in video_id).replace("?", "").replace("&", "")
+        # get URL of thumbnail
+        video_thumb = "https://img.youtube.com/vi/" + video_id + "/0.jpg"
+    elif "vimeo" in data:
+        # get ID from Vimeo URL
+        vimeo_id_regex = re.compile("(?:/video/)(\d+)")
+        vimeo_id = vimeo_id_regex.findall(data)[0]
+        # make an API call to get thumbnail URL
+        with urllib.request.urlopen("https://vimeo.com/api/v2/video/" + vimeo_id + ".json") as url:
+            data = json.loads(url.read().decode())
+            video_thumb = data[0]['thumbnail_large']
+    else:
+        # the thumbs parameter is True, but the APOD for the date is not a video, output nothing
+        video_thumb = ""
+
+    return video_thumb
+
+
+def _get_apod_chars(dt, thumbs):
     media_type = 'image'
     date_str = dt.strftime('%y%m%d')
     apod_url = '%sap%s.html' % (BASE, date_str)
@@ -64,6 +88,9 @@ def _get_apod_chars(dt):
     if hd_data:
         props['hdurl'] = hd_data
 
+    if thumbs and media_type == "video":
+        props['thumbnail_url'] = _get_thumbs(data)
+
     return props
 
 
@@ -94,7 +121,7 @@ def _copyright(soup):
     LOG.debug('getting the copyright')
     try:
         # Handler for later APOD entries
-        # There's no uniform handling of copyright (sigh). Well, we just have to 
+        # There's no uniform handling of copyright (sigh). Well, we just have to
         # try every stinking text block we find...
 
         copyright_text = None
@@ -168,7 +195,7 @@ def _explanation(soup):
     return s
 
 
-def parse_apod(dt, use_default_today_date=False):
+def parse_apod(dt, use_default_today_date=False, thumbs=False):
     """
     Accepts a date in '%Y-%m-%d' format. Returns the URL of the APOD image
     of that day, noting that
@@ -177,19 +204,19 @@ def parse_apod(dt, use_default_today_date=False):
     LOG.debug('apod chars called date:' + str(dt))
 
     try:
-        return _get_apod_chars(dt)
+        return _get_apod_chars(dt, thumbs)
 
     except Exception as ex:
 
         # handle edge case where the service local time
         # miss-matches with 'todays date' of the underlying APOD
         # service (can happen because they are deployed in different
-        # timezones). Use the fallback of prior day's date 
+        # timezones). Use the fallback of prior day's date
 
         if use_default_today_date:
             # try to get the day before
             dt = dt - timedelta(days=1)
-            return _get_apod_chars(dt)
+            return _get_apod_chars(dt, thumbs)
         else:
             # pass exception up the call stack
             LOG.error(str(ex))

--- a/apod/utility.py
+++ b/apod/utility.py
@@ -89,7 +89,8 @@ def _get_apod_chars(dt, thumbs):
         props['hdurl'] = hd_data
 
     if thumbs and media_type == "video":
-        props['thumbnail_url'] = _get_thumbs(data)
+        if thumbs.lower() == "true":
+            props['thumbnail_url'] = _get_thumbs(data)
 
     return props
 


### PR DESCRIPTION
This API was throwing 500 error when an APOD was neither an image nor a video - a situation like that happened on Oct 7, 2018, when the APOD was a flash animation. I fixed it, and now the API returns everything correctly, without errors.