### PR TITLE
Added check for stacked URLs

### DIFF
--- a/apod/utility.py
+++ b/apod/utility.py
@@ -46,6 +46,10 @@ def _get_thumbs(data):
 
     return video_thumb
 
+# function that returns only last URL if there are multiple URLs stacked together
+def _get_last_url(data):
+    regex = re.compile("(?:.(?!http[s]?://))+$")
+    return regex.findall(data)[0]
 
 def _get_apod_chars(dt, thumbs):
     media_type = 'image'
@@ -83,11 +87,11 @@ def _get_apod_chars(dt, thumbs):
         props['copyright'] = copyright_text
     props['media_type'] = media_type
     if data:
-        props['url'] = data
+        props['url'] = _get_last_url(data)
     props['date'] = dt.isoformat()
 
     if hd_data:
-        props['hdurl'] = hd_data
+        props['hdurl'] = _get_last_url(hd_data)
 
     if thumbs and media_type == "video":
         if thumbs.lower() == "true":


### PR DESCRIPTION
Fixes #6, uses a negative lookahead regex to get only last URL that starts either with http or https.