### PR TITLE
Rework default date

### DIFF
--- a/apod/utility.py
+++ b/apod/utility.py
@@ -291,26 +291,24 @@ def parse_apod(dt, use_default_today_date=False, thumbs=False):
 
     LOG.debug('apod chars called date:' + str(dt))
 
-    return _get_apod_chars(dt, thumbs)
+    try:
+        return _get_apod_chars(dt, thumbs)
 
-    # try:
-    #     return _get_apod_chars(dt, thumbs)
-    #
-    # except Exception as ex:
-    #
-    #     # handle edge case where the service local time
-    #     # miss-matches with 'todays date' of the underlying APOD
-    #     # service (can happen because they are deployed in different
-    #     # timezones). Use the fallback of prior day's date
-    #
-    #     if use_default_today_date:
-    #         # try to get the day before
-    #         dt = dt - timedelta(days=1)
-    #         return _get_apod_chars(dt, thumbs)
-    #     else:
-    #         # pass exception up the call stack
-    #         LOG.error(str(ex))
-    #         raise Exception(ex)
+    except Exception as ex:
+
+        # handle edge case where the service local time
+        # miss-matches with 'todays date' of the underlying APOD
+        # service (can happen because they are deployed in different
+        # timezones). Use the fallback of prior day's date
+
+        if use_default_today_date and dt:
+            # try to get the day before
+            dt = dt - datetime.timedelta(days=1)
+            return _get_apod_chars(dt, thumbs)
+        else:
+            # pass exception up the call stack
+            LOG.error(str(ex))
+            raise Exception(ex)
 
 
 def get_concepts(request, text, apikey):

--- a/apod/utility.py
+++ b/apod/utility.py
@@ -53,8 +53,8 @@ def _get_last_url(data):
 
 def _get_apod_chars(dt, thumbs):
     media_type = 'image'
-    date_str = dt.strftime('%y%m%d')
     if dt:
+        date_str = dt.strftime('%y%m%d')
         apod_url = '%sap%s.html' % (BASE, date_str)
     else:
         apod_url = '%sastropix.html' % BASE

--- a/application.py
+++ b/application.py
@@ -127,10 +127,12 @@ def _get_json_for_date(input_date, use_concept_tags, thumbs):
     if not input_date:
         # fall back to using today's date IF they didn't specify a date
         use_default_today_date = True
+        dt = input_date  # None
 
     # validate input date
-    dt = datetime.strptime(input_date, '%Y-%m-%d').date()
-    _validate_date(dt)
+    else:
+        dt = datetime.strptime(input_date, '%Y-%m-%d').date()
+        _validate_date(dt)
 
     # get data
     data = _apod_handler(dt, use_concept_tags, use_default_today_date, thumbs)

--- a/application.py
+++ b/application.py
@@ -126,7 +126,6 @@ def _get_json_for_date(input_date, use_concept_tags, thumbs):
     use_default_today_date = False
     if not input_date:
         # fall back to using today's date IF they didn't specify a date
-        input_date = datetime.strftime(datetime.today(), '%Y-%m-%d')
         use_default_today_date = True
 
     # validate input date

--- a/application.py
+++ b/application.py
@@ -299,7 +299,7 @@ def page_not_found(e):
     """
     Return a custom 404 error.
     """
-    LOG.info('Invalid page request: ' + e)
+    LOG.info('Invalid page request: ' + str(e))
     return _abort(404, 'Sorry, Nothing at this URL.', usage=True)
 
 


### PR DESCRIPTION
When the `&date=` parameter is left out of the query, the API currently defaults to `datetime.datetime.today().date()`, which is essentially "today UTC". This works, usually, but starting at 00:00 UTC until the next APOD image is uploaded, this API will 404 when requesting the current APOD image.

I saw that the API has a fallback to yesterday's date if today doesn't work, but for some reason this fallback either isn't helping or isn't actually implemented in production. I chose to assume it was implemented in production, but wasn't helping. This was my fix for the issue, under that assumption.

I implemented the `_date` helper function so, when a user makes a request without specifying `date`, instead of using the datetime module's implementation of "today", makes a request to https://apod.nasa.gov/apod/astropix.html, which will be the most recent valid APOD image. This essentially means the default is handled by apod.nasa.gov, so the API shouldn't 404 anymore when the `date` parameter is left out of the API query.

My function processes the HTML returned by apod.nasa.gov and, similarly to how the other helper functions work, returns a datetime.date object created from the date detected on that page. This is the code that actually allows a request to be made to astropix.html instead of the standard formatted date string, while still returning the picture's upload date in the JSON data.