### PR TITLE
Use new API for urllib3

### DIFF
--- a/apod/utility.py
+++ b/apod/utility.py
@@ -12,7 +12,7 @@ import requests
 import logging
 import json
 import re
-import urllib3 as urllib
+import urllib3
 # import urllib.request
 
 LOG = logging.getLogger(__name__)
@@ -21,6 +21,8 @@ logging.basicConfig(level=logging.WARN)
 # location of backing APOD service
 BASE = 'https://apod.nasa.gov/apod/'
 
+# Create urllib3 Pool Manager
+http = urllib3.PoolManager()
 
 # function for getting video thumbnails
 def _get_thumbs(data):
@@ -37,9 +39,9 @@ def _get_thumbs(data):
         vimeo_id_regex = re.compile("(?:/video/)(\d+)")
         vimeo_id = vimeo_id_regex.findall(data)[0]
         # make an API call to get thumbnail URL
-        with urllib.request.urlopen("https://vimeo.com/api/v2/video/" + vimeo_id + ".json") as url:
-            data = json.loads(url.read().decode())
-            video_thumb = data[0]['thumbnail_large']
+        vimeo_request = http.request("GET", "https://vimeo.com/api/v2/video/" + vimeo_id + ".json")
+        data = json.loads(vimeo_request.data.decode('utf-8'))
+        video_thumb = data[0]['thumbnail_large']
     else:
         # the thumbs parameter is True, but the APOD for the date is not a video, output nothing
         video_thumb = ""


### PR DESCRIPTION
The old usage of urllib was incompatible with urllib3, and as such all Vimeo video results with thumbs=true were causing Internal Server Errors. This PR updates to the proper usage of urllib3.

See also: https://urllib3.readthedocs.io/en/latest/user-guide.html

This fixes #59 