### PR TITLE
Update README.md | "boolean" strings enum possibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ as parameters to a http GET request. A JSON dictionary is returned nominally.
 **Fields**
 
 - `date` A string in YYYY-MM-DD format indicating the date of the APOD image (example: 2014-11-03).  Defaults to today's date.  Must be after 1995-06-16, the first day an APOD picture was posted.  There are no images for tomorrow available through this API.
-- `concept_tags` A boolean indicating whether concept tags should be returned with the rest of the response.  The concept tags are not necessarily included in the explanation, but rather derived from common search tags that are associated with the description text.  (Better than just pure text search.)  Defaults to False.
-- `hd` A boolean parameter indicating whether or not high-resolution images should be returned. This is present for legacy purposes, it is always ignored by the service and high-resolution urls are returned regardless.
+- `concept_tags` A boolean `True|False` indicating whether concept tags should be returned with the rest of the response.  The concept tags are not necessarily included in the explanation, but rather derived from common search tags that are associated with the description text.  (Better than just pure text search.)  Defaults to False.
+- `hd` A boolean `True|False` parameter indicating whether or not high-resolution images should be returned. This is present for legacy purposes, it is always ignored by the service and high-resolution urls are returned regardless.
 - `count` A positive integer, no greater than 100. If this is specified then `count` randomly chosen images will be returned in a JSON array. Cannot be used in conjunction with `date` or `start_date` and `end_date`.
 - `start_date` A string in YYYY-MM-DD format indicating the start of a date range. All images in the range from `start_date` to `end_date` will be returned in a JSON array. Cannot be used with `date`.
 - `end_date` A string in YYYY-MM-DD format indicating that end of a date range. If `start_date` is specified without an `end_date` then `end_date` defaults to the current date.
-- `thumbs` If set to `true`, the API returns URL of video thumbnail. If an APOD is not a video, this parameter is ignored.
+- `thumbs` If set to `true|false`, the API returns URL of video thumbnail. If an APOD is not a video, this parameter is ignored.
 
 **Returned fields**
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ as parameters to a http GET request. A JSON dictionary is returned nominally.
 - `count` A positive integer, no greater than 100. If this is specified then `count` randomly chosen images will be returned in a JSON array. Cannot be used in conjunction with `date` or `start_date` and `end_date`.
 - `start_date` A string in YYYY-MM-DD format indicating the start of a date range. All images in the range from `start_date` to `end_date` will be returned in a JSON array. Cannot be used with `date`.
 - `end_date` A string in YYYY-MM-DD format indicating that end of a date range. If `start_date` is specified without an `end_date` then `end_date` defaults to the current date.
-- `thumbs` If set to `true|false`, the API returns URL of video thumbnail. If an APOD is not a video, this parameter is ignored.
+- `thumbs` A boolean parameter `True|False` inidcating whether the API should return a thumbnail image URL for video files. If set to `True`, the API returns URL of video thumbnail. If an APOD is not a video, this parameter is ignored.
 
 **Returned fields**
 


### PR DESCRIPTION
Added "boolean" strings enum possibilities in order to correctly map to
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value

Does the "false" case not necessary since are "strings that looks like boolean"?

## Side issue
Like some HTML attributes the boolean could be "has | not has" the key despite the value.
Rif:
https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/has