### PR TITLE
added X-RateLimit-Limit, X-RateLimit-Remaining headers to Access-Control-Expose-Headers configuration

### DIFF
--- a/application.py
+++ b/application.py
@@ -28,7 +28,7 @@ import logging
 #from wsgiref.simple_server import make_server
 
 application = Flask(__name__)
-CORS(application)
+CORS(application, resources={r"/api/*": {"expose_headers": ["X-RateLimit-Limit","X-RateLimit-Remaining"]}})
 
 LOG = logging.getLogger(__name__)
 # logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
### Fix the issue X-RateLimit-Limit, X-RateLimit-Remaining headers weren't able to be accessed by browsers

This PR try to fix the issue we have with apod-api which describe here https://github.com/nasa/apod-api/issues/64

_I think it is also critical that API consumer can monitor their API limits autonomously in applications. Since Expose Header is not set and thus almost every trusted modern browsers are preventing API consumers from accessing the X-RateLimit-Limit, X-RateLimit-Remaining headers._ #64 