### PR TITLE
Fix the issue X-RateLimit-Limit, X-RateLimit-Remaining headers weren't able to be accessed by browsers

### DIFF
--- a/application.py
+++ b/application.py
@@ -28,7 +28,7 @@ import logging
 #from wsgiref.simple_server import make_server
 
 application = Flask(__name__)
-CORS(application)
+CORS(application, resources={r"/*": {"expose_headers": ["X-RateLimit-Limit","X-RateLimit-Remaining"]} })
 
 LOG = logging.getLogger(__name__)
 # logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
### Fix the issue X-RateLimit-Limit, X-RateLimit-Remaining headers weren't able to be accessed by browsers

**This PR attempts to fix the issue we have with accessing X-RateLimit-Remaining headers in apod-api which described here #64** 

_I think it is also critical that API consumer can monitor their API limits autonomously in applications. Since Expose Header is not set and thus almost every trusted modern browsers are preventing API consumers from accessing the X-RateLimit-Limit, X-RateLimit-Remaining headers._ 