### PR TITLE
Fix docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3-alpine
 
+RUN apk add zlib-dev jpeg-dev gcc musl-dev
+
 WORKDIR /usr/src/app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
**Why this PR?**
When building docker image, Pillow couldn't get installed due to missing support libraries in the Alpine OS.

**What did I do?**
Add missing libraries in Dockerfile, build and run the docker. Docker successfully build the image.