### PR TITLE
Update utility.py

### DIFF
--- a/apod/utility.py
+++ b/apod/utility.py
@@ -227,7 +227,8 @@ def _explanation(soup):
     s = soup.find_all('p')[2].text
     s = s.replace('\n', ' ')
     s = s.replace('  ', ' ')
-    s = s.strip(' ').strip('Explanation: ')
+    s = s.strip(' ')
+    s = s.replace('Explanation: ', '')
     s = s.split(' Tomorrow\'s picture')[0]
     s = s.strip(' ')
     if s == '':


### PR DESCRIPTION
For today's (1/1/2022) explanation, the 'E' in 'Every' was being removed (similar behavior to #87). 

strip removes individual leading / trailing characters that match, not just the whole word. Want to remove the whole word.