### PR TITLE
 Addressing Issue#76. Adding start_date, end_date parameters to the _get_json_for_random_dates function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,10 @@ as parameters to a http GET request. A JSON dictionary is returned nominally.
 - `date` A string in YYYY-MM-DD format indicating the date of the APOD image (example: 2014-11-03).  Defaults to today's date.  Must be after 1995-06-16, the first day an APOD picture was posted.  There are no images for tomorrow available through this API.
 - `concept_tags` A boolean `True|False` indicating whether concept tags should be returned with the rest of the response.  The concept tags are not necessarily included in the explanation, but rather derived from common search tags that are associated with the description text.  (Better than just pure text search.)  Defaults to False.
 - `hd` A boolean `True|False` parameter indicating whether or not high-resolution images should be returned. This is present for legacy purposes, it is always ignored by the service and high-resolution urls are returned regardless.
-- `count` A positive integer, no greater than 100. If this is specified then `count` randomly chosen images will be returned in a JSON array. Cannot be used in conjunction with `date` or `start_date` and `end_date`.
+- `count` A positive integer, no greater than 100. If this is specified then `count` randomly chosen images will be returned in a JSON array.
+Cannot be used in conjunction with `date`. Optionally can be used with `start_date` and\or `end_date` to limit a date range.  
+If `start_date` is specified without an `end_date` then `end_date` defaults to the current date.  
+If `end_date` is specified without a `start_date` then `start_date` defaults to June 16th 1995.
 - `start_date` A string in YYYY-MM-DD format indicating the start of a date range. All images in the range from `start_date` to `end_date` will be returned in a JSON array. Cannot be used with `date`.
 - `end_date` A string in YYYY-MM-DD format indicating that end of a date range. If `start_date` is specified without an `end_date` then `end_date` defaults to the current date.
 - `thumbs` A boolean parameter `True|False` inidcating whether the API should return a thumbnail image URL for video files. If set to `True`, the API returns URL of video thumbnail. If an APOD is not a video, this parameter is ignored.

--- a/application.py
+++ b/application.py
@@ -147,20 +147,40 @@ def _get_json_for_date(input_date, use_concept_tags, thumbs):
     return jsonify(data)
 
 
-def _get_json_for_random_dates(count, use_concept_tags, thumbs):
+def _get_json_for_random_dates(count, use_concept_tags, thumbs, start_date=None, end_date=None):
     """
     This returns the JSON data for a set of randomly chosen dates. The number of dates is specified by the count
-    parameter
-    :param count:
-    :param use_concept_tags:
-    :return:
+    parameter. Optionally date range can be specified by providing start_date and/or end_date.
+    :param count: Number of Json objects to return (between 1 and 100)
+    :param use_concept_tags: bool.
+    :param thumbs: bool.
+    :param start_date: optional. If not provided - default value "datetime(1995, 6, 16)" will be used
+    :param end_date: optional. If not provided - default value "datetime.today()" will be used
+    :return: list of json objects
     """
-    if count > 100 or count <= 0:
+    if count >= 100 or count < 0:
         raise ValueError('Count must be positive and cannot exceed 100')
-    begin_ordinal = datetime(1995, 6, 16).toordinal()
-    today_ordinal = datetime.today().toordinal()
 
-    random_date_ordinals = list(range(begin_ordinal, today_ordinal + 1))
+    start_dt = datetime.strptime(start_date, '%Y-%m-%d').date() if start_date else datetime(1995, 6, 16).date()
+    end_dt = datetime.strptime(end_date, '%Y-%m-%d').date() if end_date else datetime.today().date()
+    _validate_date(start_dt)
+    _validate_date(end_dt)
+
+    start_ordinal = start_dt.toordinal()
+    end_ordinal = end_dt.toordinal()
+    today_ordinal = datetime.today().date().toordinal()
+
+    delta = (end_ordinal - start_ordinal) + 1
+    # check if start date comes after end date
+    if delta <= 0:
+        raise ValueError('start_date cannot be after end_date')
+
+    # check if there enough dates in the date range to return requested count of the pictures
+    if count > delta:
+        raise ValueError('The requested count number exceeds the number of days in the requested range.'
+                         ' (reduce count number or extend the date range)')
+
+    random_date_ordinals = list(range(start_ordinal, end_ordinal + 1))
     shuffle(random_date_ordinals)
 
     all_data = []
@@ -274,6 +294,9 @@ def apod():
 
         elif not input_date and not start_date and not end_date and count:
             return _get_json_for_random_dates(int(count), use_concept_tags, thumbs)
+
+        elif not input_date and (start_date or end_date) and count:
+            return _get_json_for_random_dates(int(count), use_concept_tags, thumbs, start_date, end_date)
 
         elif not count and not input_date and start_date:
             return _get_json_for_date_range(start_date, end_date, use_concept_tags, thumbs)


### PR DESCRIPTION
### Based on: https://github.com/nasa/apod-api/issues/76

### Extended function "_get_json_for_random_dates" to accept optional start_date and\or end_date parameters.
If only start_date is provided - the current date will be used as an end_date.  
if only end_date provided - 6/16/1995 will be used as a start_date.  

The function will raise value error if: 
- count number exceeds the number of dates in the provided range
- start date is after the end date

### Updated readme.md to reflect my changes.
