### PR TITLE
bump beautilulSoup from 4.5.3 to 4.11.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask-cors>=3.0.7
 gunicorn==19.5.0
 Jinja2>=2.8
 Werkzeug>=0.10.4
-beautifulsoup4==4.5.3
+beautifulsoup4==4.11.1
 requests>=2.20.0
 coverage==4.1
 nose==1.3.7


### PR DESCRIPTION
This bump should address issues [101](https://github.com/nasa/apod-api/issues/101) and [99](https://github.com/nasa/apod-api/issues/99)
