### PR TITLE
Fix Docker build command failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.9-alpine
 
 WORKDIR /usr/src/app
 COPY requirements.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3-alpine
 
 WORKDIR /usr/src/app
 COPY requirements.txt ./
+RUN apk add -u zlib-dev jpeg-dev gcc musl-dev
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 5000


### PR DESCRIPTION
This PR solves two issues:
1. The Python version in the old Dockerfile was tied to the latest version of the `3-alpine` Docker image. This created an error in the `docker build` command where the Python version was no longer compatible with the version of Pillow. [This issue](https://github.com/nasa/apod-api/issues/99) gives a more detailed explanation of the problem. This PR locks the python version to `3.9`.
2. The `pip install` layer of the Dockerfile fails because the image does not have the dependancies necessary to install everything in `requirements.txt`. [This issue](https://github.com/nasa/apod-api/issues/97) gives a more detailed explanation of the problem. This PR adds a layer in the Dockerfile to install these dependancies.

Closes #97
Closes #99