### PR TITLE
Support embedded HTML5  <video> tags

### DIFF
--- a/apod/utility.py
+++ b/apod/utility.py
@@ -92,6 +92,10 @@ def _get_apod_chars(dt, thumbs):
         # its a video
         media_type = 'video'
         data = soup.iframe['src']
+    elif soup.video:
+        # its an HTML5 video <video> tag
+        media_type = "video"
+        data = BASE + soup.video.source["src"]
     else:
         # it is neither image nor video, output empty urls
         media_type = 'other'


### PR DESCRIPTION
Adjust media_type detection to include embedded <video> HTML5 tags


The API fails with at least one type of APOD. Today's APOD, May 18th 2024 is an embedded html5 < video >. The utility.py doesn't recognize it cause it's expecting videos to be iframes.

This new `elif` statement fixes the `media_type` and `url` for APODs that are HTML5 videos embedded directly in the HTML.

## Before
```json
{
  "date": "2025-05-18",
  "explanation": "What if you could fly over Pluto -- what might you see? The New Horizons spacecraft did just this in 2015 July as it shot past the distant world at a speed of about 80,000 kilometers per hour. Images from this spectacular passage have been color enhanced, vertically scaled, and digitally combined into the featured two-minute time-lapse video. As your journey begins, light dawns on mountains thought to be composed of water ice but colored by frozen nitrogen.  Soon, to your right, you see a flat sea of mostly solid nitrogen that has segmented into strange polygons that are thought to have bubbled up from a comparatively warm interior.  Craters and ice mountains are common sights below. The video dims and ends over terrain dubbed bladed because it shows 500-meter high ridges separated by kilometer-sized gaps.  The robotic New Horizons spacecraft has too much momentum to ever return to Pluto and is now headed out of our Solar System.",
  "media_type": "other",
  "service_version": "v1",
  "title": "Pluto Flyover from New Horizons"
}
```

## After (With this change)
```json
{
  "date": "2025-05-18",
  "explanation": "What if you could fly over Pluto -- what might you see? The New Horizons spacecraft did just this in 2015 July as it shot past the distant world at a speed of about 80,000 kilometers per hour. Images from this spectacular passage have been color enhanced, vertically scaled, and digitally combined into the featured two-minute time-lapse video. As your journey begins, light dawns on mountains thought to be composed of water ice but colored by frozen nitrogen.  Soon, to your right, you see a flat sea of mostly solid nitrogen that has segmented into strange polygons that are thought to have bubbled up from a comparatively warm interior.  Craters and ice mountains are common sights below. The video dims and ends over terrain dubbed bladed because it shows 500-meter high ridges separated by kilometer-sized gaps.  The robotic New Horizons spacecraft has too much momentum to ever return to Pluto and is now headed out of our Solar System.",
  "media_type": "video",
  "service_version": "v1",
  "title": "Pluto Flyover from New Horizons",
  "url": "https://apod.nasa.gov/apod/image/2505/PlutoFlyover_NewHorizons.mp4"
}
```

## Related issues
I believe this issue is described in [this issue](https://github.com/nasa/apod-api/issues/129) and this PR will fix it.