### PR TITLE
Change exposed port from 5000 to 8000 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /usr/src/app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-EXPOSE 5000
+EXPOSE 8000
 ENTRYPOINT ["python"]
 CMD ["application.py"]


### PR DESCRIPTION
Updated the Dockerfile to expose port 8000 instead of 5000. This aligns the container's exposed port with the application's expected runtime port.