### PR TITLE
fix: quote curl URL to prevent shell & splitting

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -44,8 +44,8 @@
   </p>
   <p>
     <font size="+2">
-      <pre>
-curl http://{{ service_url }}/{{ version }}/{{ methodname }}/?concept_tags=True&amp;date=2015-10-11
+<pre>
+curl "http://{{ service_url }}/{{ version }}/{{ methodname }}/?concept_tags=True&amp;date=2015-10-11"
 </pre>
     </font>
   </p>


### PR DESCRIPTION
The curl example in the HTML template was missing quotes around the URL.
In bash, an unquoted & sends the rest of the command to the background as a separate process  so query params like
 date= never actually reach the server.
Without quotes:
<img width="934" height="476" alt="image" src="https://github.com/user-attachments/assets/47e44170-d5e3-4185-bf25-7cc70d5a2244" />
Fix
Wrap the URL in double quotes.
With quotes:
<img width="922" height="399" alt="image" src="https://github.com/user-attachments/assets/4d2af26b-b62b-44bc-add9-1c7834e343bd" />